### PR TITLE
fix: 调用 startMarquee 前判断自身宽度

### DIFF
--- a/Sources/JXMarqueeView.swift
+++ b/Sources/JXMarqueeView.swift
@@ -113,7 +113,9 @@ public class JXMarqueeView: UIView {
                 containerView.addSubview(otherContentView)
             }
 
-            self.startMarquee()
+            if self.bounds.size.width != 0 {
+                self.startMarquee()
+            }
         }else {
             if contentViewFrameConfigWhenCantMarquee != nil {
                 contentViewFrameConfigWhenCantMarquee!(validContentView)


### PR DESCRIPTION
在 layout 时，`self.bounds.size` 可能为 `0`，待下次 layout 才会正常，此时不应该触发跑马灯。